### PR TITLE
Update 3rd party dependencies

### DIFF
--- a/Console/Obfuscar.Console.csproj
+++ b/Console/Obfuscar.Console.csproj
@@ -66,8 +66,8 @@
     <None Include="lextudio.snk" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ILRepack" Version="2.0.17" />
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+    <PackageReference Include="ILRepack" Version="2.0.18" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="Rollbar" Version="3.2.0" />
   </ItemGroup>
 </Project>

--- a/GlobalTools/GlobalTools.csproj
+++ b/GlobalTools/GlobalTools.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
   </ItemGroup>
 
 </Project>

--- a/Obfuscar/Obfuscar.csproj
+++ b/Obfuscar/Obfuscar.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.1" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.2" />
     <PackageReference Include="Rollbar" Version="3.2.0" />
     <PackageReference Include="System.Runtime.Caching" Version="4.5.0" />
   </ItemGroup>

--- a/ObfuscarTest/ObfuscarTest.csproj
+++ b/ObfuscarTest/ObfuscarTest.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <ProjectGuid>{FD20FE24-37FE-46D0-ADBF-2B54D2874C2A}</ProjectGuid>
     <FileUpgradeFlags />
-    <IsTestProject>true</IsTestProject>
     <UpgradeBackupLocation />
     <TargetFramework>net461</TargetFramework>
     <PublishUrl>publish\</PublishUrl>
@@ -39,7 +38,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.1" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.2" />
     <PackageReference Include="System.CodeDom" Version="4.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">


### PR DESCRIPTION
Bump Mono.Cecil, ILRepack and .Net Options
to the latest (stable) version.