### PR TITLE
Support assembly level obfuscation attributes

### DIFF
--- a/Obfuscar.nuspec
+++ b/Obfuscar.nuspec
@@ -21,6 +21,6 @@
 	<files>
 		<!-- Include everything in \build -->
     <file src="build\**" target="build" />
-    <file src="bin\release\net452\obfuscar.console.exe" target="tools" />
+    <file src="bin\release\net452\obfuscar.console.*" target="tools" />
 	</files>
 </package>

--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -470,9 +470,7 @@ namespace Obfuscar
 
             // skip filtered fields
             string skip;
-            if (info.ShouldSkip(fieldKey, Project.InheritMap, Project.Settings.KeepPublicApi,
-                Project.Settings.HidePrivateApi,
-                Project.Settings.MarkedOnly, typeInXaml, out skip))
+            if (info.ShouldSkip(fieldKey, Project.InheritMap, Project.Settings.MarkedOnly, typeInXaml, out skip))
             {
                 Mapping.UpdateField(fieldKey, ObfuscationStatus.Skipped, skip);
                 nameGroup.Add(fieldKey.Name);
@@ -536,8 +534,7 @@ namespace Obfuscar
 
                     string skip;
                     // rename the class parameters
-                    if (info.ShouldSkip(new TypeKey(type), Project.InheritMap, Project.Settings.KeepPublicApi,
-                        Project.Settings.HidePrivateApi, Project.Settings.MarkedOnly, out skip))
+                    if (info.ShouldSkip(new TypeKey(type), Project.InheritMap, Project.Settings.MarkedOnly, out skip))
                         continue;
 
                     int index = 0;
@@ -551,8 +548,7 @@ namespace Obfuscar
         {
             MethodKey methodkey = new MethodKey(method);
             string skip;
-            if (info.ShouldSkipParams(methodkey, Project.InheritMap, Project.Settings.KeepPublicApi,
-                Project.Settings.HidePrivateApi, Project.Settings.MarkedOnly, out skip))
+            if (info.ShouldSkipParams(methodkey, Project.InheritMap, Project.Settings.MarkedOnly, out skip))
                 return;
 
             foreach (ParameterDefinition param in method.Parameters)
@@ -599,8 +595,7 @@ namespace Obfuscar
                     string fullName = type.FullName;
 
                     string skip;
-                    if (info.ShouldSkip(unrenamedTypeKey, Project.InheritMap, Project.Settings.KeepPublicApi,
-                        Project.Settings.HidePrivateApi, Project.Settings.MarkedOnly, out skip))
+                    if (info.ShouldSkip(unrenamedTypeKey, Project.InheritMap, Project.Settings.MarkedOnly, out skip))
                     {
                         Mapping.UpdateType(oldTypeKey, ObfuscationStatus.Skipped, skip);
 
@@ -921,9 +916,7 @@ namespace Obfuscar
 
             string skip;
             // skip filtered props
-            if (info.ShouldSkip(propKey, typeInXaml, Project.InheritMap, Project.Settings.KeepPublicApi,
-                Project.Settings.HidePrivateApi,
-                Project.Settings.MarkedOnly, out skip))
+            if (info.ShouldSkip(propKey, typeInXaml, Project.InheritMap, Project.Settings.MarkedOnly, out skip))
             {
                 m.Update(ObfuscationStatus.Skipped, skip);
 
@@ -1051,9 +1044,7 @@ namespace Obfuscar
 
             string skip;
             // skip filtered events
-            if (info.ShouldSkip(evtKey, Project.InheritMap, Project.Settings.KeepPublicApi,
-                Project.Settings.HidePrivateApi,
-                Project.Settings.MarkedOnly, out skip))
+            if (info.ShouldSkip(evtKey, Project.InheritMap, Project.Settings.MarkedOnly, out skip))
             {
                 m.Update(ObfuscationStatus.Skipped, skip);
 
@@ -1179,8 +1170,7 @@ namespace Obfuscar
 
             // skip filtered methods
             string skiprename;
-            var toDo = info.ShouldSkip(methodKey, Project.InheritMap, Project.Settings.KeepPublicApi,
-                Project.Settings.HidePrivateApi, Project.Settings.MarkedOnly, out skiprename);
+            var toDo = info.ShouldSkip(methodKey, Project.InheritMap, Project.Settings.MarkedOnly, out skiprename);
             if (!toDo)
                 skiprename = null;
             // update status for skipped non-virtual methods immediately...status for

--- a/Obfuscar/Project.cs
+++ b/Obfuscar/Project.cs
@@ -202,7 +202,7 @@ namespace Obfuscar
                 if (info.Exclude)
                 {
                     project.CopyAssemblyList.Add(info);
-                    break;
+                    continue;
                 }
 
                 Console.WriteLine("Processing assembly: " + info.Definition.Name.FullName);
@@ -373,7 +373,15 @@ namespace Obfuscar
             // make each assembly's list of member refs
             foreach (AssemblyInfo info in AssemblyList)
             {
-                info.Init();
+                try
+                {
+                    info.Init();
+                }
+                catch
+                {
+                    Console.WriteLine("\nError processing " + info.Definition.FullName);
+                    throw;
+                }
             }
 
             // build inheritance map

--- a/ObfuscarTest/Input/AssemblyWithAssemblyAttr.cs
+++ b/ObfuscarTest/Input/AssemblyWithAssemblyAttr.cs
@@ -1,0 +1,32 @@
+[assembly: System.Reflection.ObfuscationAttribute(Exclude = false, Feature = "all")]
+
+namespace TestClasses
+{
+    public enum PublicEnumA { A, B };
+
+    public enum PublicEnumB { A, B };
+
+	public class PublicClassA
+	{
+        public void PublicMethodA()
+        {
+        }
+
+        public void PublicMethodB()
+        {
+        }
+
+        public int PublicPropertyA { get; set; }
+
+        public int PublicPropertyB { get; set; }
+    }
+
+    public class PublicClassB
+    {
+        public void PublicMethodA()
+        {
+        }
+
+        public int PublicPropertyA { get; set; }
+    }
+}

--- a/ObfuscarTest/InterfaceTests.cs
+++ b/ObfuscarTest/InterfaceTests.cs
@@ -66,7 +66,7 @@ namespace ObfuscarTest
                 if (property.Name == name)
                     return property;
 
-            Assert.True(false, string.Format("Expected to find method: {0}", name));
+            Assert.True(false, string.Format("Expected to find property: {0}", name));
             return null; // never here
         }
 

--- a/ObfuscarTest/ObfuscationAttributeTests.cs
+++ b/ObfuscarTest/ObfuscationAttributeTests.cs
@@ -35,13 +35,23 @@ namespace ObfuscarTest
                 Assert.True(false, $"Unable to compile test assembly:  AssemblyB, {cr.Errors[0].ErrorText}");
         }
 
-        static MethodDefinition FindByName(TypeDefinition typeDef, string name)
+        static MethodDefinition FindMethodByName(TypeDefinition typeDef, string name)
         {
             foreach (MethodDefinition method in typeDef.Methods)
                 if (method.Name == name)
                     return method;
 
             Assert.True(false, string.Format("Expected to find method: {0}", name));
+            return null; // never here
+        }
+
+        PropertyDefinition FindPropertyByName(TypeDefinition typeDef, string name)
+        {
+            foreach (PropertyDefinition property in typeDef.Properties)
+                if (property.Name == name)
+                    return property;
+
+            Assert.True(false, string.Format("Expected to find property: {0}", name));
             return null; // never here
         }
 
@@ -68,7 +78,7 @@ namespace ObfuscarTest
             {
                 TypeDefinition classAType = inAssmDef.MainModule.GetType("TestClasses.InternalClass");
                 ObfuscatedThing classA = map.GetClass(new TypeKey(classAType));
-                var classAmethod1 = FindByName(classAType, "PublicMethod");
+                var classAmethod1 = FindMethodByName(classAType, "PublicMethod");
                 var method = map.GetMethod(new MethodKey(classAmethod1));
 
                 TypeDefinition nestedClassAType = classAType.NestedTypes[0];
@@ -88,7 +98,7 @@ namespace ObfuscarTest
             {
                 TypeDefinition classAType = inAssmDef.MainModule.GetType("TestClasses.InternalClass3");
                 ObfuscatedThing classA = map.GetClass(new TypeKey(classAType));
-                var classAmethod1 = FindByName(classAType, "PublicMethod");
+                var classAmethod1 = FindMethodByName(classAType, "PublicMethod");
                 var method = map.GetMethod(new MethodKey(classAmethod1));
 
                 TypeDefinition nestedClassAType = classAType.NestedTypes[0];
@@ -107,7 +117,7 @@ namespace ObfuscarTest
 
             TypeDefinition classBType = inAssmDef.MainModule.GetType("TestClasses.PublicClass");
             ObfuscatedThing classB = map.GetClass(new TypeKey(classBType));
-            var classBmethod1 = FindByName(classBType, "PublicMethod");
+            var classBmethod1 = FindMethodByName(classBType, "PublicMethod");
             var method2 = map.GetMethod(new MethodKey(classBmethod1));
 
             Assert.True(classB.Status == ObfuscationStatus.Renamed, "PublicClass should have been obfuscated.");
@@ -115,7 +125,7 @@ namespace ObfuscarTest
 
             TypeDefinition classCType = inAssmDef.MainModule.GetType("TestClasses.InternalClass2");
             ObfuscatedThing classC = map.GetClass(new TypeKey(classCType));
-            var classCmethod1 = FindByName(classCType, "PublicMethod");
+            var classCmethod1 = FindMethodByName(classCType, "PublicMethod");
             var method1 = map.GetMethod(new MethodKey(classCmethod1));
 
             TypeDefinition nestedClassBType = classCType.NestedTypes[0];
@@ -132,9 +142,9 @@ namespace ObfuscarTest
             {
                 TypeDefinition classDType = inAssmDef.MainModule.GetType("TestClasses.PublicClass2");
                 ObfuscatedThing classD = map.GetClass(new TypeKey(classDType));
-                var classDmethod1 = FindByName(classDType, "PublicMethod");
+                var classDmethod1 = FindMethodByName(classDType, "PublicMethod");
                 var method3 = map.GetMethod(new MethodKey(classDmethod1));
-                var classDmethod2 = FindByName(classDType, "ProtectedMethod");
+                var classDmethod2 = FindMethodByName(classDType, "ProtectedMethod");
                 var method4 = map.GetMethod(new MethodKey(classDmethod2));
 
                 Assert.True(classD.Status == ObfuscationStatus.Skipped, "PublicClass2 shouldn't have been obfuscated.");
@@ -145,11 +155,11 @@ namespace ObfuscarTest
             {
                 TypeDefinition classDType = inAssmDef.MainModule.GetType("TestClasses.PublicClass3");
                 ObfuscatedThing classD = map.GetClass(new TypeKey(classDType));
-                var classDmethod1 = FindByName(classDType, "PublicMethod");
+                var classDmethod1 = FindMethodByName(classDType, "PublicMethod");
                 var method3 = map.GetMethod(new MethodKey(classDmethod1));
-                var classDmethod2 = FindByName(classDType, "ProtectedMethod");
+                var classDmethod2 = FindMethodByName(classDType, "ProtectedMethod");
                 var method4 = map.GetMethod(new MethodKey(classDmethod2));
-                var classDmethod3 = FindByName(classDType, "PublicMethod2");
+                var classDmethod3 = FindMethodByName(classDType, "PublicMethod2");
                 var method5 = map.GetMethod(new MethodKey(classDmethod3));
 
                 Assert.True(classD.Status == ObfuscationStatus.Skipped, "PublicClass2 shouldn't have been obfuscated.");
@@ -247,7 +257,7 @@ namespace ObfuscarTest
 
             TypeDefinition classBType = inAssmDef.MainModule.GetType("TestClasses.PublicClass");
             ObfuscatedThing classB = map.GetClass(new TypeKey(classBType));
-            var classBmethod1 = FindByName(classBType, "PublicMethod");
+            var classBmethod1 = FindMethodByName(classBType, "PublicMethod");
             var method2 = map.GetMethod(new MethodKey(classBmethod1));
 
             Assert.True(classB.Status == ObfuscationStatus.Renamed, "PublicClass should have been obfuscated.");
@@ -292,7 +302,7 @@ namespace ObfuscarTest
 
             TypeDefinition classAType = inAssmDef.MainModule.GetType("TestClasses.InternalClass");
             ObfuscatedThing classA = map.GetClass(new TypeKey(classAType));
-            var classAmethod1 = FindByName(classAType, "PublicMethod");
+            var classAmethod1 = FindMethodByName(classAType, "PublicMethod");
             var method = map.GetMethod(new MethodKey(classAmethod1));
 
             TypeDefinition nestedClassAType = classAType.NestedTypes[0];
@@ -309,7 +319,7 @@ namespace ObfuscarTest
 
             TypeDefinition classBType = inAssmDef.MainModule.GetType("TestClasses.PublicClass");
             ObfuscatedThing classB = map.GetClass(new TypeKey(classBType));
-            var classBmethod1 = FindByName(classBType, "PublicMethod");
+            var classBmethod1 = FindMethodByName(classBType, "PublicMethod");
             var method2 = map.GetMethod(new MethodKey(classBmethod1));
 
             Assert.True(classB.Status == ObfuscationStatus.Renamed, "PublicClass should have been obfuscated.");
@@ -317,7 +327,7 @@ namespace ObfuscarTest
 
             TypeDefinition classCType = inAssmDef.MainModule.GetType("TestClasses.InternalClass2");
             ObfuscatedThing classC = map.GetClass(new TypeKey(classCType));
-            var classCmethod1 = FindByName(classCType, "PublicMethod");
+            var classCmethod1 = FindMethodByName(classCType, "PublicMethod");
             var method1 = map.GetMethod(new MethodKey(classCmethod1));
 
             TypeDefinition nestedClassBType = classCType.NestedTypes[0];
@@ -335,11 +345,77 @@ namespace ObfuscarTest
 
             TypeDefinition classDType = inAssmDef.MainModule.GetType("TestClasses.PublicClass2");
             ObfuscatedThing classD = map.GetClass(new TypeKey(classDType));
-            var classDmethod1 = FindByName(classDType, "PublicMethod");
+            var classDmethod1 = FindMethodByName(classDType, "PublicMethod");
             var method3 = map.GetMethod(new MethodKey(classDmethod1));
 
             Assert.True(classD.Status == ObfuscationStatus.Skipped, "PublicClass2 shouldn't have been obfuscated.");
             Assert.True(method3.Status == ObfuscationStatus.Renamed, "PublicMethod should have been obfuscated.");
+        }
+
+        [Fact]
+        public void CheckAssemblyAttribute()
+        {
+            const string assmName = "AssemblyWithAssemblyAttr";
+
+            string xml = string.Format(
+                @"<?xml version='1.0'?>" +
+                @"				<Obfuscator>" +
+                @"				<Var name='InPath' value='{0}' />" +
+                @"				<Var name='OutPath' value='{1}' />" +
+                @"              <Var name='KeepPublicApi' value='true' />" +
+                @"              <Var name='HidePrivateApi' value='true' />" +
+                @"				<Module file='$(InPath){2}{3}.dll' >" +
+                @"                <SkipType name = 'TestClasses.PublicEnumB' skipFields = 'true' />" +
+                @"                <SkipMethod name = 'PublicMethodB' type = 'TestClasses.PublicClassA' />" +
+                @"                <SkipProperty name = 'PublicPropertyB' type = 'TestClasses.PublicClassA' />" +
+                @"                <SkipType name = 'TestClasses.PublicClassB' skipFields = 'true' skipMethods = 'true' skipProperties = 'true' />" +
+                @"				</Module>" +
+                @"				</Obfuscator>", TestHelper.InputPath, TestHelper.OutputPath, Path.DirectorySeparatorChar, assmName);
+
+            var obfuscator = TestHelper.BuildAndObfuscate(assmName, string.Empty, xml);
+            var map = obfuscator.Mapping;
+
+            AssemblyDefinition inAssmDef = AssemblyDefinition.ReadAssembly(Path.Combine(TestHelper.InputPath, assmName + ".dll"));
+
+            var enumTypeA = inAssmDef.MainModule.GetType("TestClasses.PublicEnumA");
+            var obfuscatedEnumA = map.GetClass(new TypeKey(enumTypeA));
+            Assert.Equal(ObfuscationStatus.Renamed, obfuscatedEnumA.Status);
+
+            var enumTypeB = inAssmDef.MainModule.GetType("TestClasses.PublicEnumB");
+            var obfuscatedEnumB = map.GetClass(new TypeKey(enumTypeB));
+            Assert.Equal(ObfuscationStatus.Skipped, obfuscatedEnumB.Status);
+
+            var classTypeA = inAssmDef.MainModule.GetType("TestClasses.PublicClassA");
+            var obfuscatedClassA = map.GetClass(new TypeKey(classTypeA));
+            Assert.Equal(ObfuscationStatus.Renamed, obfuscatedClassA.Status);
+
+            var methodA = FindMethodByName(classTypeA, "PublicMethodA");
+            var obfuscatedMethodA = map.GetMethod(new MethodKey(methodA));
+            Assert.Equal(ObfuscationStatus.Renamed, obfuscatedMethodA.Status);
+
+            var methodB = FindMethodByName(classTypeA, "PublicMethodB");
+            var obfuscatedMethodB = map.GetMethod(new MethodKey(methodB));
+            Assert.Equal(ObfuscationStatus.Skipped, obfuscatedMethodB.Status);
+
+            var propertyA = FindPropertyByName(classTypeA, "PublicPropertyA");
+            var obfuscatedPropertyA = map.GetProperty(new PropertyKey(new TypeKey(classTypeA), propertyA));
+            Assert.Equal(ObfuscationStatus.Renamed, obfuscatedPropertyA.Status);
+
+            var propertyB = FindPropertyByName(classTypeA, "PublicPropertyB");
+            var obfuscatedPropertyB = map.GetProperty(new PropertyKey(new TypeKey(classTypeA), propertyB));
+            Assert.Equal(ObfuscationStatus.Skipped, obfuscatedPropertyB.Status);
+
+            var classTypeB = inAssmDef.MainModule.GetType("TestClasses.PublicClassB");
+            var obfuscatedClassB = map.GetClass(new TypeKey(classTypeB));
+            Assert.Equal(ObfuscationStatus.Skipped, obfuscatedClassB.Status);
+
+            methodA = FindMethodByName(classTypeB, "PublicMethodA");
+            obfuscatedMethodA = map.GetMethod(new MethodKey(methodA));
+            Assert.Equal(ObfuscationStatus.Skipped, obfuscatedMethodA.Status);
+
+            propertyA = FindPropertyByName(classTypeB, "PublicPropertyA");
+            obfuscatedPropertyA = map.GetProperty(new PropertyKey(new TypeKey(classTypeB), propertyA));
+            Assert.Equal(ObfuscationStatus.Skipped, obfuscatedPropertyA.Status);
         }
     }
 }


### PR DESCRIPTION
Support assembly level obfuscation attributes to enable setting global assembly settings in code. This will give similar behavior as Crypto Obfuscator regarding assembly attributes.