### PR TITLE
Generic types in attributes fix

### DIFF
--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -426,7 +426,7 @@ namespace Obfuscar
                     {
                         if (ca.Type.FullName == "System.Type" && ca.Value != null)
                         {
-                            typerefs.Add((TypeReference) ca.Value);
+                            AddTypeDefFromAttribute(typerefs, (TypeReference)ca.Value);
                             continue;
                         }
 
@@ -435,7 +435,7 @@ namespace Obfuscar
                         {
                             foreach (CustomAttributeArgument caArg in attributeTypeArguments)
                             {
-                                typerefs.Add((TypeReference)caArg.Value);
+                                AddTypeDefFromAttribute(typerefs, (TypeReference)caArg.Value);
                             }
                         }
                     }
@@ -446,6 +446,21 @@ namespace Obfuscar
             unrenamedTypeReferences = new List<TypeReference>(typerefs);
 
             initialized = true;
+        }
+
+        /// <summary>
+        /// Due to the unknown reason TypeReference inside Generic parameters inside attributes
+        /// Are unique references that differ from the same type TypeReferences in other places.
+        /// Thus we need to add generic arguments for types used as attribute constructor parameters.
+        /// </summary>
+        private void AddTypeDefFromAttribute(HashSet<TypeReference> typerefs, TypeReference type)
+        {
+            typerefs.Add(type);
+            if (type is GenericInstanceType gt)
+            {
+                foreach (var p in gt.GenericArguments)
+                    AddTypeDefFromAttribute(typerefs, p);
+            }
         }
 
         private class Graph

--- a/ObfuscarTest/AttributeWithGenericTypeParamTest.cs
+++ b/ObfuscarTest/AttributeWithGenericTypeParamTest.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.CodeDom.Compiler;
+using System.IO;
+using System.Linq;
+using Mono.Cecil;
+using Xunit;
+
+namespace ObfuscarTest
+{
+    public class AttributeWithGenericTypeParamTest
+    {
+        public string BuildAndObfuscate()
+        {
+            string outputPath = TestHelper.OutputPath;
+            var nameA = "AssemblyA";
+            var name = "AttributeWithGenericTypeParam";
+
+
+            var provider = new Microsoft.CSharp.CSharpCodeProvider();
+            var cp = new CompilerParameters();
+            cp.GenerateExecutable = false;
+            cp.GenerateInMemory = false;
+            cp.TreatWarningsAsErrors = true;
+
+            string assemblyAPath = Path.Combine(TestHelper.InputPath, nameA + ".dll");
+            cp.OutputAssembly = assemblyAPath;
+            var cr = provider.CompileAssemblyFromFile(cp, Path.Combine(TestHelper.InputPath, nameA + ".cs"));
+            if (cr.Errors.Count > 0)
+                Assert.True(false, $"Unable to compile test assembly: {nameA}, {cr.Errors[0].ErrorText}");
+
+            cp.ReferencedAssemblies.Add(assemblyAPath);
+            cp.OutputAssembly = Path.Combine(TestHelper.InputPath, name + ".dll");
+            cr = provider.CompileAssemblyFromFile(cp, Path.Combine(TestHelper.InputPath, name + ".cs"));
+            if (cr.Errors.Count > 0)
+                Assert.True(false, $"Unable to compile test assembly:  {name}, {cr.Errors[0].ErrorText}");
+
+            var xml = string.Format(
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Var name='KeepPublicApi' value='false' />" +
+                @"<Var name='HidePrivateApi' value='true' />" +
+                @"<Module file='$(InPath){2}{4}.dll' />" +
+                @"<Module file='$(InPath){2}{3}.dll' />" +
+                @"</Obfuscator>", TestHelper.InputPath, outputPath, Path.DirectorySeparatorChar, name, nameA);
+
+            TestHelper.Obfuscate(xml);
+            return Path.Combine(outputPath, $"{name}.dll");
+        }
+
+        [Fact]
+        public void CheckAttributesWithGenericTypes()
+        {
+            var output = BuildAndObfuscate();
+            var assmDef = AssemblyDefinition.ReadAssembly(output);
+
+            Assert.Equal(2+1, assmDef.MainModule.Types.Count);
+
+            var attr = assmDef.MainModule.Types
+                .SelectMany(x => x.CustomAttributes)
+                .SelectMany(x => x.ConstructorArguments)
+                .Select(x => x.Value)
+                .OfType<GenericInstanceType>()
+                // expect only 1 attribute param like List<ClassA>
+                .Single();
+
+            Assert.True(attr.FullName.Contains("List"));
+            Assert.False(attr.FullName.Contains("ClassA"), "Reference to the ClassA has not been updated");
+        }
+    }
+}

--- a/ObfuscarTest/Input/AttributeWithGenericTypeParam.cs
+++ b/ObfuscarTest/Input/AttributeWithGenericTypeParam.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+
+[assembly: System.Reflection.ObfuscationAttribute(Exclude = false, Feature = "all")]
+
+namespace TestClasses
+{
+    /// <summary>
+    /// Some attribute that accept type as parameter
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class AttributeWithTypeAttribute : Attribute
+    {
+        public Type PersistedType;
+
+        public AttributeWithTypeAttribute(Type persistedType)
+        {
+            PersistedType = persistedType;
+        }
+    }
+
+    /// <summary>
+    /// Use list (from non-renamed assembly) with generic items class from renamed assembly
+    /// To make sure we handle it recursively (going deeper)
+    /// </summary>
+    [AttributeWithType(typeof(List<ClassA>))]
+    public class ClassWithGenericRenamedAttributeArgument
+    {
+        /// <summary>Dummy field to ensure the assemblies are copied into the output dir</summary>
+        public static int Smth = -1;
+
+        /// <summary>
+        /// Reference ClassA directly to make sure compiler keep reference to the assembly A
+        /// </summary>
+        public static ClassA A { get; set; }
+    }
+
+}

--- a/ObfuscarTest/ObfuscarTest.csproj
+++ b/ObfuscarTest/ObfuscarTest.csproj
@@ -85,6 +85,7 @@
     <Compile Remove="Input\AssemblyWithTypesAttrs.cs" />
     <Compile Remove="Input\AssemblyWithTypesAttrs2.cs" />
     <Compile Remove="Input\AssemblyWithTypesAttrs3.cs" />
+    <Compile Remove="Input\AttributeWithGenericTypeParam.cs" />
     <Compile Remove="Input\SkipVirtualMethodTest.cs" />
     <Compile Remove="Input\SkipMethodWithDynamicParameterTest.cs" />
   </ItemGroup>


### PR DESCRIPTION
Solve obfuscar that failed to update
[ExternalPersistor(bla-bla, typeof(MeshImmutable<**STV**, **STF**>))]
So MeshImmutable is updated but generic arguments STV/STF does not