### PR TITLE
Fix collection expression syntax obfuscation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ T4MVC.cs
 
 /ObfuscarTest/Input/*.dll
 /ObfuscarTest/Input/*.exe
-/ObfuscarTest/Output
+/ObfuscarTestNet/Input/*.dll
 /packages
 /Examples/BasicExample/Final
 /Examples/BasicExample/Obfuscator_Input

--- a/Obfuscar.sln
+++ b/Obfuscar.sln
@@ -24,6 +24,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B2A0589A-CCAD-4BA1-97AD-771424706E0D}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.gitignore = .gitignore
 		Obfuscar.nuspec = Obfuscar.nuspec
 		readme.md = readme.md
 		test.bat = test.bat
@@ -35,7 +36,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Baml", "Baml\Baml.csproj", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ObfuscarTest.FluentAssertions", "ObfuscarTest.FluentAssertions\ObfuscarTest.FluentAssertions.csproj", "{F608F808-617E-4F16-8C9D-E6A6A401A5EB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ObfuscarTestNet", "ObfuscarTestNet\ObfuscarTestNet.csproj", "{463CE737-FEBF-4B48-96AF-374B9D2D1A11}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ObfuscarTestNet", "ObfuscarTestNet\ObfuscarTestNet.csproj", "{463CE737-FEBF-4B48-96AF-374B9D2D1A11}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Obfuscar.sln
+++ b/Obfuscar.sln
@@ -35,6 +35,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Baml", "Baml\Baml.csproj", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ObfuscarTest.FluentAssertions", "ObfuscarTest.FluentAssertions\ObfuscarTest.FluentAssertions.csproj", "{F608F808-617E-4F16-8C9D-E6A6A401A5EB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ObfuscarTestNet", "ObfuscarTestNet\ObfuscarTestNet.csproj", "{463CE737-FEBF-4B48-96AF-374B9D2D1A11}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -195,6 +197,30 @@ Global
 		{F608F808-617E-4F16-8C9D-E6A6A401A5EB}.winphone_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F608F808-617E-4F16-8C9D-E6A6A401A5EB}.winphone_Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F608F808-617E-4F16-8C9D-E6A6A401A5EB}.winphone_Release|Any CPU.Build.0 = Release|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.net_2_0_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.net_2_0_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.net_2_0_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.net_2_0_Release|Any CPU.Build.0 = Release|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.net_3_5_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.net_3_5_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.net_3_5_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.net_3_5_Release|Any CPU.Build.0 = Release|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.net_4_0_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.net_4_0_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.net_4_0_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.net_4_0_Release|Any CPU.Build.0 = Release|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.silverlight_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.silverlight_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.silverlight_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.silverlight_Release|Any CPU.Build.0 = Release|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.winphone_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.winphone_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.winphone_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{463CE737-FEBF-4B48-96AF-374B9D2D1A11}.winphone_Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -86,12 +86,6 @@ namespace Obfuscar
         {
             AssemblyInfo info = new AssemblyInfo(project);
 
-            // Anonymous type obfuscation does not work
-            info.skipTypes.Add(new TypeTester("*AnonymousType*", TypeAffectFlags.AffectProperty | TypeAffectFlags.AffectMethod | 
-                TypeAffectFlags.AffectField | TypeAffectFlags.AffectEvent | TypeAffectFlags.AffectString, "", "", null, null));
-            // The collection expression syntax [] will generate a readonly array type in the IL which fail across assemblies if obfuscated
-            info.skipTypes.Add(new TypeTester("*__ReadOnlyArray*", TypeAffectFlags.AffectField, "", "", null, null));
-
             // pull out the file attribute, but don't process anything empty
             string val = Helper.GetAttribute(reader, "file", vars);
             if (val.Length > 0)
@@ -1137,6 +1131,12 @@ namespace Obfuscar
                 return true;
             }
 
+            if (field.TypeKey.Name.Contains("__ReadOnlyArray") || field.TypeKey.Name.Contains("__ReadOnlySingleElementList"))
+            {
+                message = "collection expression";
+                return true;
+            }
+
             if (ShouldSkip(field.TypeKey, TypeAffectFlags.AffectField, map))
             {
                 message = $"type rule in configuration ({field.TypeKey})";
@@ -1274,17 +1274,17 @@ namespace Obfuscar
             return !HidePrivateApi;
         }
 
-        public bool ShouldSkip(EventKey evt, InheritMap map, bool markedOnly,
+        public bool ShouldSkip(EventKey evnt, InheritMap map, bool markedOnly,
             out string message)
         {
             // skip runtime special events
-            if (evt.Event.IsRuntimeSpecialName)
+            if (evnt.Event.IsRuntimeSpecialName)
             {
                 message = "runtime special name";
                 return true;
             }
 
-            var attribute = evt.Event.MarkedToRename();
+            var attribute = evnt.Event.MarkedToRename();
             // skip runtime methods
             if (attribute != null)
             {
@@ -1292,7 +1292,7 @@ namespace Obfuscar
                 return !attribute.Value;
             }
 
-            var parent = evt.DeclaringType.MarkedToRename();
+            var parent = evnt.DeclaringType.MarkedToRename();
             if (parent != null)
             {
                 message = "type attribute";
@@ -1305,34 +1305,34 @@ namespace Obfuscar
                 return true;
             }
 
-            if (ShouldForce(evt.TypeKey, TypeAffectFlags.AffectEvent, map))
+            if (ShouldForce(evnt.TypeKey, TypeAffectFlags.AffectEvent, map))
             {
-                message = $"type rule in configuration ({evt.TypeKey})";
+                message = $"type rule in configuration ({evnt.TypeKey})";
                 return false;
             }
 
-            if (forceEvents.IsMatch(evt, map))
+            if (forceEvents.IsMatch(evnt, map))
             {
                 message = "event rule in configuration";
                 return false;
             }
 
-            if (ShouldSkip(evt.TypeKey, TypeAffectFlags.AffectEvent, map))
+            if (ShouldSkip(evnt.TypeKey, TypeAffectFlags.AffectEvent, map))
             {
-                message = $"type rule in configuration ({evt.TypeKey})";
+                message = $"type rule in configuration ({evnt.TypeKey})";
                 return true;
             }
 
-            if (skipEvents.IsMatch(evt, map))
+            if (skipEvents.IsMatch(evnt, map))
             {
                 message = "event rule in configuration";
                 return true;
             }
 
-            if (evt.Event.IsPublic() && (
-                evt.DeclaringType.IsTypePublic() ||
-                evt.Event.AddMethod != null && map.GetMethodGroup(new MethodKey(evt.Event.AddMethod))?.Methods?.FirstOrDefault(m => m.DeclaringType.IsTypePublic()) != null ||
-                evt.Event.RemoveMethod != null && map.GetMethodGroup(new MethodKey(evt.Event.RemoveMethod))?.Methods?.FirstOrDefault(m => m.DeclaringType.IsTypePublic()) != null
+            if (evnt.Event.IsPublic() && (
+                evnt.DeclaringType.IsTypePublic() ||
+                evnt.Event.AddMethod != null && map.GetMethodGroup(new MethodKey(evnt.Event.AddMethod))?.Methods?.FirstOrDefault(m => m.DeclaringType.IsTypePublic()) != null ||
+                evnt.Event.RemoveMethod != null && map.GetMethodGroup(new MethodKey(evnt.Event.RemoveMethod))?.Methods?.FirstOrDefault(m => m.DeclaringType.IsTypePublic()) != null
             ))
             {
                 message = KeepPublicApiOptionInConfiguration;

--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -86,6 +86,12 @@ namespace Obfuscar
         {
             AssemblyInfo info = new AssemblyInfo(project);
 
+            // Anonymous type obfuscation does not work
+            info.skipTypes.Add(new TypeTester("*AnonymousType*", TypeAffectFlags.AffectProperty | TypeAffectFlags.AffectMethod | 
+                TypeAffectFlags.AffectField | TypeAffectFlags.AffectEvent | TypeAffectFlags.AffectString, "", "", null, null));
+            // The collection expression syntax [] will generate a readonly array type in the IL which fail across assemblies if obfuscated
+            info.skipTypes.Add(new TypeTester("*__ReadOnlyArray*", TypeAffectFlags.AffectField, "", "", null, null));
+
             // pull out the file attribute, but don't process anything empty
             string val = Helper.GetAttribute(reader, "file", vars);
             if (val.Length > 0)

--- a/Obfuscar/NameGroup.cs
+++ b/Obfuscar/NameGroup.cs
@@ -33,11 +33,13 @@ namespace Obfuscar
 {
     class NameGroup : IEnumerable<string>
     {
+        Random _random = new Random();
+
         HashSet<string> names = new HashSet<string>();
 
         public string GetNext()
         {
-            int index = 0;
+            int index = _random.Next(20);
             string name;
             for (;;)
             {

--- a/Obfuscar/Properties/AssemblyInfo.cs
+++ b/Obfuscar/Properties/AssemblyInfo.cs
@@ -29,6 +29,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: InternalsVisibleTo("ObfuscarTest")]
+[assembly: InternalsVisibleTo("ObfuscarTestNet")]
 [assembly: InternalsVisibleTo("ObfuscarTest.FluentAssertions")]
 
 // General Information about an assembly is controlled through the following 

--- a/ObfuscarTestNet/CollectionExpressionTest.cs
+++ b/ObfuscarTestNet/CollectionExpressionTest.cs
@@ -1,5 +1,4 @@
 ﻿using ObfuscarTestNet;
-using ObfuscarTestNet.Input;
 using System;
 using System.IO;
 using System.Linq;
@@ -24,7 +23,7 @@ namespace ObfuscarTest
                 @"<Module file='$(InPath){2}AssemblyWithCollectionExpression.dll'/>" +
                 @"</Obfuscator>", TestHelper.InputPath, outputPath, Path.DirectorySeparatorChar);
 
-            var output = TestHelper.BuildAndObfuscate(["AssemblyWithCollectionArgument", "AssemblyWithCollectionExpression"], xml);
+            var output = TestHelper.BuildAndObfuscate(new[] { "AssemblyWithCollectionArgument", "AssemblyWithCollectionExpression" }, xml);
 
             var assembly1 = Assembly.LoadFrom(Path.GetFullPath(Path.Combine(outputPath, "AssemblyWithCollectionArgument.dll")));
             var assembly2 = Assembly.LoadFrom(Path.GetFullPath(Path.Combine(outputPath, "AssemblyWithCollectionExpression.dll")));
@@ -35,7 +34,7 @@ namespace ObfuscarTest
             var instance = Activator.CreateInstance(type);
 
             var obfuscatedMethodName = obfuscatedClass.Value.Methods.First(m => m.Value.Name.EndsWith("Test[0]")).Value.StatusText;
-            type.GetMethod(obfuscatedMethodName)!.Invoke(instance, []);
+            type.GetMethod(obfuscatedMethodName)!.Invoke(instance, null);
         }
     }
 }

--- a/ObfuscarTestNet/CollectionExpressionTest.cs
+++ b/ObfuscarTestNet/CollectionExpressionTest.cs
@@ -1,0 +1,45 @@
+﻿using ObfuscarTestNet;
+using ObfuscarTestNet.Input;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace ObfuscarTest
+{
+    [TestClass]
+    public class CollectionExpressionTest
+    {
+        [TestMethod]
+        public void CheckCollectionExpression()
+        {
+            string outputPath = TestHelper.OutputPath;
+            string xml = string.Format(
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Var name='KeepPublicApi' value='false' />" +
+                @"<Module file='$(InPath){2}AssemblyWithCollectionArgument.dll'>" +
+//                @"  <SkipType name=""*__ReadOnlyArray*"" skipProperties=""true"" skipMethods=""true"" skipFields=""true"" />" +
+                @"</Module>" +
+//                @"<Module file='$(InPath){2}AssemblyWithCollectionExpression.dll'>" +
+                @"  <SkipType name=""*__ReadOnlyArray*"" skipProperties=""true"" skipMethods=""true"" skipFields=""true"" />" +
+                @"</Module>" +
+                @"</Obfuscator>", TestHelper.InputPath, outputPath, Path.DirectorySeparatorChar);
+
+            var output = TestHelper.BuildAndObfuscate(["AssemblyWithCollectionArgument", "AssemblyWithCollectionExpression"], xml);
+
+            var assembly1 = Assembly.LoadFrom(Path.GetFullPath(Path.Combine(outputPath, "AssemblyWithCollectionArgument.dll")));
+            var assembly2 = Assembly.LoadFrom(Path.GetFullPath(Path.Combine(outputPath, "AssemblyWithCollectionExpression.dll")));
+            var obfuscatedClass = output.Mapping.ClassMap.First(c => c.Key.Name == "ObfuscarTestNet.Input.AssemblyWithCollectionExpression");
+            var obfuscatedClassName = obfuscatedClass.Value.StatusText;
+            obfuscatedClassName = obfuscatedClassName[(obfuscatedClassName.IndexOf(']') + 1)..];
+            var type = assembly2.GetType(obfuscatedClassName) ?? throw new Exception($"Test class {obfuscatedClassName} not found");
+            var instance = Activator.CreateInstance(type);
+
+            var obfuscatedMethodName = obfuscatedClass.Value.Methods.First(m => m.Value.Name.EndsWith("Test[0]")).Value.StatusText;
+            type.GetMethod(obfuscatedMethodName)!.Invoke(instance, []);
+        }
+    }
+}

--- a/ObfuscarTestNet/CollectionExpressionTest.cs
+++ b/ObfuscarTestNet/CollectionExpressionTest.cs
@@ -20,12 +20,8 @@ namespace ObfuscarTest
                 @"<Var name='InPath' value='{0}' />" +
                 @"<Var name='OutPath' value='{1}' />" +
                 @"<Var name='KeepPublicApi' value='false' />" +
-                @"<Module file='$(InPath){2}AssemblyWithCollectionArgument.dll'>" +
-//                @"  <SkipType name=""*__ReadOnlyArray*"" skipProperties=""true"" skipMethods=""true"" skipFields=""true"" />" +
-                @"</Module>" +
-//                @"<Module file='$(InPath){2}AssemblyWithCollectionExpression.dll'>" +
-                @"  <SkipType name=""*__ReadOnlyArray*"" skipProperties=""true"" skipMethods=""true"" skipFields=""true"" />" +
-                @"</Module>" +
+                @"<Module file='$(InPath){2}AssemblyWithCollectionArgument.dll'/>" +
+                @"<Module file='$(InPath){2}AssemblyWithCollectionExpression.dll'/>" +
                 @"</Obfuscator>", TestHelper.InputPath, outputPath, Path.DirectorySeparatorChar);
 
             var output = TestHelper.BuildAndObfuscate(["AssemblyWithCollectionArgument", "AssemblyWithCollectionExpression"], xml);

--- a/ObfuscarTestNet/Input/AssemblyWithCollectionArgument.cs
+++ b/ObfuscarTestNet/Input/AssemblyWithCollectionArgument.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ObfuscarTestNet.Input
+{
+    public class AssemblyWithCollectionArgument
+    {
+        int a, b;
+
+        public void Method(IEnumerable<AssemblyWithCollectionArgument> items)
+        {
+            Console.WriteLine("Count: " + items.Count());
+        }
+
+        public void Method(IEnumerable<int> items)
+        {
+            Console.WriteLine("Count: " + items.Count());
+        }
+
+        public void Method(IEnumerable<string> items)
+        {
+            Console.WriteLine("Count: " + items.Count());
+        }
+
+        public void Test()
+        {
+            var value = new AssemblyWithCollectionArgument();
+            value.Method([value, value]);
+            value.Method([1, 2]);
+            value.Method(["a", "b"]);
+        }
+    }
+}

--- a/ObfuscarTestNet/Input/AssemblyWithCollectionExpression.cs
+++ b/ObfuscarTestNet/Input/AssemblyWithCollectionExpression.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ObfuscarTestNet.Input
+{
+    class AssemblyWithCollectionExpression
+    {
+        int a, b, c;
+
+        public void Test()
+        {
+            var value = new AssemblyWithCollectionArgument();
+            value.Method([1, 2]);
+            value.Method([value, value]);
+        }
+    }
+}

--- a/ObfuscarTestNet/ObfuscarTestNet.csproj
+++ b/ObfuscarTestNet/ObfuscarTestNet.csproj
@@ -2,12 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
-    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Input\**" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />

--- a/ObfuscarTestNet/ObfuscarTestNet.csproj
+++ b/ObfuscarTestNet/ObfuscarTestNet.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Obfuscar\Obfuscar.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+    <Using Include="System.Text.RegularExpressions" />
+    <Using Include="System.Threading.Tasks" />
+  </ItemGroup>
+
+</Project>

--- a/ObfuscarTestNet/SourceBuilder.cs
+++ b/ObfuscarTestNet/SourceBuilder.cs
@@ -33,7 +33,6 @@ namespace ObfuscarTestNet
             var outPath = Path.ChangeExtension(fileName, "dll");
             var compilationResult = compilation.Emit(outPath);
 
-
             // Compilation Error handling
             if (!compilationResult.Success)
                 throw new Exception(string.Join("\n", compilationResult.Diagnostics));
@@ -103,12 +102,9 @@ namespace ObfuscarTestNet
                 runtimePath + "System.Private.CoreLib.dll",
                 runtimePath + "System.Runtime.dll",
                 runtimePath + "System.Console.dll",
-                runtimePath + "netstandard.dll",
-
-                runtimePath + "System.Text.RegularExpressions.dll", // IMPORTANT!
+                runtimePath + "System.Text.RegularExpressions.dll",
                 runtimePath + "System.Linq.dll",
-                runtimePath + "System.Linq.Expressions.dll", // IMPORTANT!
-
+                runtimePath + "System.Linq.Expressions.dll",
                 runtimePath + "System.IO.dll",
                 runtimePath + "System.Net.Primitives.dll",
                 runtimePath + "System.Net.Http.dll",
@@ -118,11 +114,9 @@ namespace ObfuscarTestNet
                 runtimePath + "System.Globalization.dll",
                 runtimePath + "System.Collections.Concurrent.dll",
                 runtimePath + "System.Collections.NonGeneric.dll",
-                runtimePath + "Microsoft.CSharp.dll"
+                runtimePath + "Microsoft.CSharp.dll",
+                runtimePath + "netstandard.dll"
             );
-
-            // this library and CodeAnalysis libs
-            //AddAssembly(GetType()); // Scripting Library
         }
     }
 }

--- a/ObfuscarTestNet/SourceBuilder.cs
+++ b/ObfuscarTestNet/SourceBuilder.cs
@@ -1,0 +1,128 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace ObfuscarTestNet
+{
+    public class SourceBuilder
+    {
+        readonly List<PortableExecutableReference> _references = new();
+
+        /// <summary>
+        /// <see href="https://weblog.west-wind.com/posts/2022/Jun/07/Runtime-CSharp-Code-Compilation-Revisited-for-Roslyn#compiling-code-with-raw-roslyn"/>
+        /// </summary>
+        public string Build(string fileName, params string[] references)
+        {
+            AddNetCoreDefaultReferences();
+            AddAssemblies(references);
+
+            var source = File.ReadAllText(fileName);
+
+            // Set up compilation Configuration
+            var tree = SyntaxFactory.ParseSyntaxTree(source);
+            var compilation = CSharpCompilation.Create(Path.GetFileName(fileName))
+                .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                    optimizationLevel: OptimizationLevel.Release))
+                .WithReferences(_references)
+                .AddSyntaxTrees(tree);
+
+            // Actually compile the code
+            var outPath = Path.ChangeExtension(fileName, "dll");
+            var compilationResult = compilation.Emit(outPath);
+
+
+            // Compilation Error handling
+            if (!compilationResult.Success)
+                throw new Exception(string.Join("\n", compilationResult.Diagnostics));
+
+            return outPath;
+        }
+
+        public bool AddAssembly(string assemblyDll)
+        {
+            if (string.IsNullOrEmpty(assemblyDll)) return false;
+
+            var file = Path.GetFullPath(assemblyDll);
+
+            if (!File.Exists(file))
+            {
+                // check framework or dedicated runtime app folder
+                var path = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+                file = Path.Combine(path, assemblyDll);
+                if (!File.Exists(file))
+                    return false;
+            }
+
+            if (_references.Any(r => r.FilePath == file)) return true;
+
+            try
+            {
+                var reference = MetadataReference.CreateFromFile(file);
+                _references.Add(reference);
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private void AddAssemblies(params string[] assemblies)
+        {
+            foreach (var assembly in assemblies)
+                AddAssembly(assembly);
+        }
+
+        public bool AddAssembly(Type type)
+        {
+            try
+            {
+                if (_references.Any(r => r.FilePath == type.Assembly.Location))
+                    return true;
+
+                var systemReference = MetadataReference.CreateFromFile(type.Assembly.Location);
+                _references.Add(systemReference);
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public void AddNetCoreDefaultReferences()
+        {
+            var runtimePath = Path.GetDirectoryName(typeof(object).Assembly.Location) + Path.DirectorySeparatorChar;
+
+            AddAssemblies(
+                runtimePath + "System.Private.CoreLib.dll",
+                runtimePath + "System.Runtime.dll",
+                runtimePath + "System.Console.dll",
+                runtimePath + "netstandard.dll",
+
+                runtimePath + "System.Text.RegularExpressions.dll", // IMPORTANT!
+                runtimePath + "System.Linq.dll",
+                runtimePath + "System.Linq.Expressions.dll", // IMPORTANT!
+
+                runtimePath + "System.IO.dll",
+                runtimePath + "System.Net.Primitives.dll",
+                runtimePath + "System.Net.Http.dll",
+                runtimePath + "System.Private.Uri.dll",
+                runtimePath + "System.Reflection.dll",
+                runtimePath + "System.ComponentModel.Primitives.dll",
+                runtimePath + "System.Globalization.dll",
+                runtimePath + "System.Collections.Concurrent.dll",
+                runtimePath + "System.Collections.NonGeneric.dll",
+                runtimePath + "Microsoft.CSharp.dll"
+            );
+
+            // this library and CodeAnalysis libs
+            //AddAssembly(GetType()); // Scripting Library
+        }
+    }
+}

--- a/ObfuscarTestNet/TestHelper.cs
+++ b/ObfuscarTestNet/TestHelper.cs
@@ -18,19 +18,6 @@ namespace ObfuscarTestNet
             get { return Path.Combine("..", "..", "Output", count++.ToString()); }
         }
 
-        public static void CleanInput()
-        {
-            // clean out inputPath
-            try
-            {
-                //foreach (string file in Directory.GetFiles(InputPath, "*.dll"))
-                //File.Delete(file);
-            }
-            catch
-            {
-            }
-        }
-
         public static string BuildAssembly(string name, params string[] references)
         {
             var builder = new SourceBuilder();
@@ -73,14 +60,12 @@ namespace ObfuscarTestNet
 
         public static Obfuscar.Obfuscator BuildAndObfuscate(string name, string xml, bool hideStrings = false)
         {
-            CleanInput();
             BuildAssembly(name);
             return Obfuscate(xml, hideStrings);
         }
 
         public static Obfuscar.Obfuscator BuildAndObfuscate(string[] names, string xml)
         {
-            CleanInput();
             BuildAssemblies(names);
             return Obfuscate(xml);
         }

--- a/ObfuscarTestNet/TestHelper.cs
+++ b/ObfuscarTestNet/TestHelper.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.CodeDom.Compiler;
+using System.Text;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace ObfuscarTestNet
+{
+    static class TestHelper
+    {
+        public static string InputPath = Path.Combine("..", "..", "..", "Input");
+
+        private static int count;
+
+        public static string OutputPath
+        {
+            get { return Path.Combine("..", "..", "Output", count++.ToString()); }
+        }
+
+        public static void CleanInput()
+        {
+            // clean out inputPath
+            try
+            {
+                //foreach (string file in Directory.GetFiles(InputPath, "*.dll"))
+                //File.Delete(file);
+            }
+            catch
+            {
+            }
+        }
+
+        public static string BuildAssembly(string name, params string[] references)
+        {
+            var builder = new SourceBuilder();
+            return builder.Build(Path.Combine(InputPath, name + ".cs"), references);
+        }
+
+        public static void BuildAssemblies(params string[] names)
+        {
+            var references = new List<string>();
+            foreach (var name in names)
+            {
+                references.Add(BuildAssembly(name, references.ToArray()));
+            }
+        }
+
+        public static Obfuscar.Obfuscator Obfuscate(string xml, bool hideStrings = false)
+        {
+            Obfuscar.Obfuscator obfuscator = Obfuscar.Obfuscator.CreateFromXml(xml);
+
+            if (hideStrings)
+                obfuscator.HideStrings();
+
+            var typeNamesInXaml = obfuscator.CollectTypesFromXaml();
+            var allPropertyTypesRelatedToNpc = obfuscator.CollectTypesRelatedToNpc();
+            var allTypeNamesRelatedToNpcOrInXaml = typeNamesInXaml
+                .Union(allPropertyTypesRelatedToNpc)
+                .ToHashSet();
+
+            obfuscator.RenameFields(typeNamesInXaml);
+            obfuscator.RenameParams();
+            obfuscator.RenameProperties(allTypeNamesRelatedToNpcOrInXaml);
+            obfuscator.RenameEvents();
+            obfuscator.RenameMethods();
+            obfuscator.RenameTypes(typeNamesInXaml);
+            obfuscator.PostProcessing();
+            obfuscator.SaveAssemblies(true);
+
+            return obfuscator;
+        }
+
+        public static Obfuscar.Obfuscator BuildAndObfuscate(string name, string xml, bool hideStrings = false)
+        {
+            CleanInput();
+            BuildAssembly(name);
+            return Obfuscate(xml, hideStrings);
+        }
+
+        public static Obfuscar.Obfuscator BuildAndObfuscate(string[] names, string xml)
+        {
+            CleanInput();
+            BuildAssemblies(names);
+            return Obfuscate(xml);
+        }
+
+        private static string GetAssemblyPath(string name)
+        {
+            return Path.Combine(InputPath, name + ".dll");
+        }
+    }
+}


### PR DESCRIPTION
The collection expression syntax, e.g. changing `new [] {1, 2, 3}` to `[1, 2, 3]` will generate a readonly array type in the IL which fails in JIT compilation across assemblies if obfuscated. This is fixed by excluding field obfuscation in the compiler generated types __ReadOnlyArray and __ReadOnlySingleElementList.
The PR also improves obfuscation a bit by not always obfuscating the same class to the same result.